### PR TITLE
Allow dashes in build paths, use replacePath for build path as well as source paths

### DIFF
--- a/tasks/lib/jade_usemin.js
+++ b/tasks/lib/jade_usemin.js
@@ -18,7 +18,7 @@ exports.task = function (grunt) {
     // set up relevant regex for jade find
     exports.regex = {
         buildRegex       : /<!-- build/,
-        buildExtractRegex: /build:(\w+)\s+((\w*[\/._]*)+)/,
+        buildExtractRegex: /build:(\w+)\s+((\w*[\/._-]*)+)/,
         endBuildRegex    : /<!-- endbuild/,
         jsSourceRegex    : /src=['"]((\w*[\/._-]*)+)['"]/,
         cssSourceRegex   : /href=['"]((\w*[\/._-]*)+)['"]/
@@ -144,6 +144,12 @@ exports.task = function (grunt) {
 
                 //look for pattern build:<type>
                 if (line.match(exports.regex.buildRegex)) {
+
+                    //replace path from options.replacePath
+                    _.each(exports.options.replacePath, function (path, key) {
+                        line = line.replace(key, path);
+                    });
+
                     extracted = line.match(exports.regex.buildExtractRegex);
                     type = extracted[1];
                     target = extracted[2];

--- a/test/fixtures/sample3.jade
+++ b/test/fixtures/sample3.jade
@@ -1,0 +1,9 @@
+//-<!-- build:js test/compiled/compiled.min-v#{config.version}.js -->
+script(src='/v#{config.version}/src/script1.js')
+script(src='/v#{config.version}/src/script2.js')
+//-<!-- endbuild -->
+
+//-<!-- build:css test/compiled/style.min-v#{config.version}.css -->
+link(rel='stylesheet', href='/test/src/style1.css')
+link(rel='stylesheet', href='/test/src/style2.css')
+//-<!-- endbuild -->


### PR DESCRIPTION
I needed to use a version number in the filename of the built file, it seemed sensible to use the current replacePath option.
