### PR TITLE
Fix for Windows paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-uglify": "^0.5.0",
-    "lodash": "^2.4.1"
+    "lodash": "^2.4.1",
+    "slash": "^0.1.3"
   }
 }

--- a/tasks/lib/jade_usemin.js
+++ b/tasks/lib/jade_usemin.js
@@ -6,6 +6,7 @@
 var path = require('path');
 var os = require('os');
 var _ = require('lodash');
+var slash = require('slash');
 
 var getFileSrc = function (str, type) {
     var result;
@@ -206,8 +207,8 @@ exports.task = function (grunt) {
     var rewriteRevs = function (summary, filerev, options) {
         _.each(summary, function (newTarget, target) {
             _.each(filerev, function (file) {
-                var dest = file.dest.replace(/\\/g, "/").replace('\\', '/');
-                var compareTarget = target.replace(/\\/g, "/").replace('\\', '/');
+                var dest = slash(file.dest);
+                var compareTarget = slash(target.replace(/\\/g, "/").replace('\\', '/'));
                 if (dest === compareTarget) {
                     grunt.file.copy(file.output, file.output, {
                         process: function (contents) {
@@ -217,8 +218,8 @@ exports.task = function (grunt) {
                                 target = target.substr(len);
                                 newTarget = newTarget.substr(len);
                             }
-                            target = target.replace(/\\/g, "/").replace('\\', '/');
-                            newTarget = newTarget.replace(/\\/g, "/").replace('\\', '/');
+                            target = slash(target);
+                            newTarget = slash(newTarget);
                             return contents.replace(target, newTarget);
                         }
                     });


### PR DESCRIPTION
The rewriteRevs function does a simple compare of paths which on Windows can result in no rewrites due to how path strings are stored. This simply takes the dest and target and unifies the slashes so that the compared path is consistent.
