### PR TITLE
plugin fails when minblock has no content

### DIFF
--- a/tasks/lib/jade_usemin.js
+++ b/tasks/lib/jade_usemin.js
@@ -315,7 +315,11 @@ exports.task = function (grunt) {
                 _.merge(extractedTargets[target], tempExtraction[target]);
                 grunt.log.oklns('Finished with target block:', target);
                 var oldTarget = unprefixedTarget || target;
-                optimizedSrc.push(insideBuildFirstItem.line.replace(insideBuildFirstItem.src, oldTarget));
+                
+                if(insideBuildFirstItem.line) {
+                    optimizedSrc.push(insideBuildFirstItem.line.replace(insideBuildFirstItem.src, oldTarget));
+                }
+                
                 //reset build vars
                 insideBuildFirstItem = {};
                 type = target = insideBuild = unprefixedTarget = null;


### PR DESCRIPTION
When there is a minblock with no content, the plugin fails to proccess it due to a replace on an undefined object.

Warning: Cannot call method 'replace' of undefined Use --force to continue.
to reproduce the problem, just set an empty min block

//-<!-- build:js /js/index.min.js -->
//-<!-- endbuild -->

FIXED #16
